### PR TITLE
migrate from ros-melodic-xacro to ros-noetic-xacro

### DIFF
--- a/kuka_kr6_support/launch/load_kr6r700sixx.launch
+++ b/kuka_kr6_support/launch/load_kr6r700sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r700sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r700sixx.xacro'"/>
 </launch>

--- a/kuka_kr6_support/launch/load_kr6r900sixx.launch
+++ b/kuka_kr6_support/launch/load_kr6r900sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 </launch>


### PR DESCRIPTION
# Problem statement

Using `ros noetic` and launching `kuka_kr6_support/launch/load_kr6r700sixx.launch` and `kuka_kr6_support/launch/load_kr6r900sixx.launch`, an error gets thrown:

```bash
Invalid <param> tag: Cannot load command parameter [robot_description]: no such command [['/opt/ros/noetic/share/xacro/xacro.py',']].
```

# Solution

`ros-noetic-xacro` does not contain the `xacro.py` file anymore. Instead, a binary is provided. The fix is implemented in this PR.

Same implementation can be found in [ros industrial](https://github.com/ros-industrial/kuka_experimental/commit/8fdb8c837dc6f1da67f5923b3b0ca38d9593db26).